### PR TITLE
feat: add --disable-telemetry option to block telemetry and Sentry

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -824,7 +824,13 @@ export async function restoreOriginal(originalPath: string): Promise<void> {
  * Filter options for removing aliases
  * Uses the same names as CLI options for consistency
  */
-export type FilterFlag = "is-custom" | "skip-login" | "websearch" | "api-base" | "reasoning-effort";
+export type FilterFlag =
+  | "is-custom"
+  | "skip-login"
+  | "websearch"
+  | "api-base"
+  | "reasoning-effort"
+  | "disable-telemetry";
 
 export interface RemoveFilterOptions {
   /** Remove aliases created by this droid-patch version */
@@ -950,6 +956,9 @@ export async function removeAliasesByFilter(filter: RemoveFilterOptions): Promis
             break;
           case "api-base":
             if (!patches.apiBase) matches = false;
+            break;
+          case "disable-telemetry":
+            if (!patches.noTelemetry) matches = false;
             break;
         }
         if (!matches) break;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -38,6 +38,8 @@ export interface AliasMetadata {
     /** @deprecated Old proxy field, kept for backward compatibility */
     proxy?: string | null;
     reasoningEffort: boolean;
+    /** Whether telemetry/Sentry is disabled */
+    noTelemetry?: boolean;
   };
 }
 
@@ -165,5 +167,6 @@ export function formatPatches(patches: AliasMetadata["patches"]): string {
   // Support old proxy field for backward compatibility
   if (patches.proxy && !patches.websearch) applied.push(`websearch(${patches.proxy})`);
   if (patches.reasoningEffort) applied.push("reasoningEffort");
+  if (patches.noTelemetry) applied.push("noTelemetry");
   return applied.length > 0 ? applied.join(", ") : "(none)";
 }


### PR DESCRIPTION
     - Add --disable-telemetry flag to completely disable data collection
     - Patch strategy:
       - Break ENABLE_SENTRY/VITE_VERCEL_ENV env vars so Sentry never initializes
       - Make flushToWeb() always return early (!0|| = always true), no fetch executed
     - Update metadata schema with noTelemetry field
     - Add disable-telemetry to FilterFlag for remove --flag support
     - Support in update command for re-applying patches